### PR TITLE
Frontend: Bandaid fix for login bug

### DIFF
--- a/client/src/app/api/getCurrentUser/route.ts
+++ b/client/src/app/api/getCurrentUser/route.ts
@@ -9,7 +9,7 @@ import axios, { AxiosError } from 'axios';
  * @returns User's profile
  */
 const getCurrentUser = async (token: string): Promise<GetCurrentUserResponse> => {
-  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.user.user}`;
+  const requestUrl = `${config.api.baseApiUrl}${config.api.endpoints.user.user}`;
   const response = await axios.get<GetCurrentUserResponse>(requestUrl, {
     headers: {
       Authorization: `Bearer ${token}`,

--- a/client/src/app/api/login/route.ts
+++ b/client/src/app/api/login/route.ts
@@ -3,12 +3,12 @@ import { setCookie } from '@/lib/services/CookieService';
 import { LoginRequest } from '@/lib/types/apiRequests';
 import { LoginResponse } from '@/lib/types/apiResponses';
 import { CookieType } from '@/lib/types/enums';
-import { getErrorMessage, getMessagesFromError } from '@/lib/utils';
+import { getErrorMessage } from '@/lib/utils';
 import axios, { AxiosError } from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 
 const login = async (email: string, password: string): Promise<LoginResponse> => {
-  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.auth.login}`;
+  const requestUrl = `${config.api.baseApiUrl}${config.api.endpoints.auth.login}`;
   const requestBody: LoginRequest = { email, password };
   const response = await axios.post<LoginResponse>(requestUrl, requestBody);
   return response.data;
@@ -18,10 +18,10 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { email, password } = body;
-    const response = await login(email, password);
-    await setCookie(CookieType.ACCESS_TOKEN, response.token);
-    await setCookie(CookieType.USER, JSON.stringify(response.user));
-    return response;
+    const loginResponse = await login(email, password);
+    setCookie(CookieType.ACCESS_TOKEN, loginResponse.token);
+    setCookie(CookieType.USER, JSON.stringify(loginResponse.user));
+    return NextResponse.json(loginResponse);
   } catch (error) {
     if (error instanceof AxiosError) {
       return NextResponse.json({ error: getErrorMessage(error) }, { status: error.status || 500 });

--- a/client/src/app/api/updateUser/route.ts
+++ b/client/src/app/api/updateUser/route.ts
@@ -10,7 +10,7 @@ const updateCurrentUserProfile = async (
   token: string,
   user: UserPatches
 ): Promise<PatchUserResponse> => {
-  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.user.user}`;
+  const requestUrl = `${config.api.baseApiUrl}${config.api.endpoints.user.user}`;
 
   const requestBody: PatchUserRequest = { user };
 

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -36,10 +36,10 @@ export default function LoginPage() {
   });
 
   const onSubmit: SubmitHandler<LoginValues> = async credentials => {
-    console.log('FUCK');
     try {
       const response = await UserAPI.login(credentials.email, credentials.password);
-      setTimeout(() => router.push('/'), 500);
+      router.refresh();
+      router.push('/');
     } catch (error) {
       setError(getErrorMessage(error));
     }

--- a/client/src/app/login/page.tsx
+++ b/client/src/app/login/page.tsx
@@ -20,6 +20,7 @@ interface LoginValues {
 }
 
 export default function LoginPage() {
+  const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | undefined>(undefined);
   const router = useRouter();
 
@@ -35,12 +36,14 @@ export default function LoginPage() {
   });
 
   const onSubmit: SubmitHandler<LoginValues> = async credentials => {
+    console.log('FUCK');
     try {
-      await UserAPI.login(credentials.email, credentials.password);
-      router.push('/');
+      const response = await UserAPI.login(credentials.email, credentials.password);
+      setTimeout(() => router.push('/'), 500);
     } catch (error) {
       setError(getErrorMessage(error));
     }
+    setLoading(false);
   };
 
   return (
@@ -82,7 +85,7 @@ export default function LoginPage() {
 
           {/* <Link href="/forgot-password">Forgot your password?</Link> */}
 
-          <Button variant="primary" onClick={handleSubmit(onSubmit)}>
+          <Button variant="primary" onClick={handleSubmit(onSubmit)} disabled={loading}>
             Login
           </Button>
 

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -7,7 +7,11 @@ import { getCookie } from '@/lib/services/CookieService';
 import { CookieType } from '@/lib/types/enums';
 
 export default async function Home() {
-  const accessToken = await getCookie(CookieType.ACCESS_TOKEN);
+  const accessToken = getCookie(CookieType.ACCESS_TOKEN);
+
+  if (!accessToken) {
+    redirect('/login');
+  }
 
   try {
     const fetchedUser = await UserAPI.getCurrentUser(accessToken);

--- a/client/src/app/profile/page.tsx
+++ b/client/src/app/profile/page.tsx
@@ -5,7 +5,7 @@ import Profile from '@/components/Profile';
 import { redirect } from 'next/navigation';
 
 export default async function ProfilePage() {
-  const accessToken = await getCookie(CookieType.ACCESS_TOKEN);
+  const accessToken = getCookie(CookieType.ACCESS_TOKEN);
 
   try {
     const fetchedUser = await UserAPI.getCurrentUser(accessToken);

--- a/client/src/components/Button/index.tsx
+++ b/client/src/components/Button/index.tsx
@@ -14,6 +14,7 @@ interface ButtonProps {
   for?: string;
   submit?: boolean;
   onClick?: () => void;
+  disabled?: boolean;
   className?: string;
 }
 
@@ -23,6 +24,7 @@ const Button = ({
   for: htmlFor,
   submit = false,
   onClick,
+  disabled,
   className = '',
   children,
 }: PropsWithChildren<ButtonProps>) => {
@@ -30,6 +32,7 @@ const Button = ({
     className: `${styles.button} ${className}`,
     'data-variant': variant,
     onClick,
+    disabled,
     children,
   };
   return htmlFor ? (

--- a/client/src/components/Button/style.module.scss
+++ b/client/src/components/Button/style.module.scss
@@ -14,6 +14,10 @@
   letter-spacing: 0.5px;
   cursor: pointer;
 
+  &:disabled {
+    background-color: vars.$neutral;
+  }
+
   &[data-variant='primary'] {
     background-color: vars.$btn-primary;
   }

--- a/client/src/lib/api/AuthAPI.ts
+++ b/client/src/lib/api/AuthAPI.ts
@@ -9,7 +9,7 @@ import axios from 'axios';
  * @returns PrivateProfile containing user information on successful creation
  */
 export const register = async (user: UserRegistration): Promise<PrivateProfile> => {
-  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.auth.register}`;
+  const requestUrl = `${config.api.baseApiUrl}${config.api.endpoints.auth.register}`;
 
   const response = await axios.post<RegistrationResponse>(requestUrl, { user: user });
 

--- a/client/src/lib/config.ts
+++ b/client/src/lib/config.ts
@@ -1,6 +1,9 @@
 const config = {
   api: {
-    baseUrl: process.env.NEXT_PUBLIC_ACM_API_URL,
+    baseApiUrl: process.env.NEXT_PUBLIC_ACM_API_URL,
+    baseUrl: process.env.VERCEL_URL
+      ? `https://${process.env.VERCEL_URL}`
+      : process.env.NEXT_PUBLIC_BASE_URL,
     endpoints: {
       auth: {
         register: '/user',

--- a/client/src/lib/services/CookieService.ts
+++ b/client/src/lib/services/CookieService.ts
@@ -1,11 +1,11 @@
 import { cookies, headers } from 'next/headers';
 
-export const getCookie = async (key: string): Promise<string> => {
-  const cookie = await cookies();
+export const getCookie = (key: string): string => {
+  const cookie = cookies();
   return cookie.get(key)?.value as string;
 };
 
-export const setCookie = async (key: string, value: string): Promise<void> => {
-  const cookie = await cookies();
+export const setCookie = (key: string, value: string) => {
+  const cookie = cookies();
   cookie.set(key, value);
 };

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -3,6 +3,7 @@ import { CookieType } from './lib/types/enums';
 
 export function middleware(request: NextRequest) {
   const userCookie = request.cookies.get(CookieType.USER);
+  const tokenCookie = request.cookies.get(CookieType.ACCESS_TOKEN);
 
   if (!userCookie) {
     return NextResponse.redirect(new URL('/login', request.url));


### PR DESCRIPTION
There's this bug where even if you successfully login, it doesn't redirect you to the new page (dashboard)
- I messed around with about 5 million different things but nothing really fixed it
- The reasoning why is even after setting the user + token cookie, there's a little delay before it becomes available, and the router renavs before the cookies get set, leading to the user getting kicked from the page they want to reroute to
- I'll annotate below some of the things I tried that didn't work, but the bandaid fix is to just refresh router before pushing
- also fixing base url because we can detect from VERCEL_URL in deploys, or BASE_URL in development