### PR TITLE
Only trigger GitHub actions if relevant files change

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -2,6 +2,7 @@ name: Auto Comment on PRs
 on:
   pull_request:
     types: [opened]
+    paths: server/**
 jobs:
   auto-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-lint-test.yml
+++ b/.github/workflows/backend-lint-test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+    paths: server/**
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -3,6 +3,7 @@ name: Frontend - Linting
 on:
   pull_request:
     branches: [main]
+    paths: client/**
 jobs:
   Linux:
     runs-on: ubuntu-latest

--- a/server/README.md
+++ b/server/README.md
@@ -1,11 +1,14 @@
 ## Setup
+
 1. Copy `.env.example` to `.env` and fill in the values
 2. Add Firebase Admin credentials to a file named `firebaseServiceAccountKey.json`, at the same level as the `.env` file.
 3. Start up Docker Desktop
 4. Spin up Postgres:
+
 ```bash
 docker-compose --env-file .env up
 ```
 
 ## Directly querying Postgres on a local build using `psql`
+
 psql -h localhost -p 5432 -U acmucsd_dev -d hackathon_portal


### PR DESCRIPTION
# Info

Towards #51.

# Description

Only trigger GitHub actions if relevant files change

## Changes

- added [`on.pull_request.paths`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) to the actions' yml files
- formatted server/README.md to see if only the backend actions trigger

# Type of Change

- [ ] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [x] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [x] My changes produce no new warnings.

# Screenshots

Before #53 | After #72
--- | ---
![image](https://github.com/user-attachments/assets/31377020-53bc-492c-9170-87c765165d9f) | ![image](https://github.com/user-attachments/assets/622bc6ec-5860-4c4d-8ef2-dbacc0037402)