### PR TITLE
Lock application edits after deadline

### DIFF
--- a/client/src/app/apply/[step]/page.tsx
+++ b/client/src/app/apply/[step]/page.tsx
@@ -1,5 +1,5 @@
 import ApplicationStep from '@/components/ApplicationStep';
-import { appQuestions } from '@/config';
+import { appQuestions, TIMELINE } from '@/config';
 import styles from './page.module.scss';
 import ApplicationReview from '@/components/ApplicationReview';
 import Progress from '@/components/Progress';
@@ -25,6 +25,7 @@ type ApplicationPageProps = {
 export default async function ApplicationPage({ params }: ApplicationPageProps) {
   const accessToken = await getCookie(CookieType.ACCESS_TOKEN);
   const step = Number((await params).step);
+  const deadlinePassed = new Date() >= TIMELINE.application;
 
   let response: ResponseModel | null = null;
   if (step < STEP_SUBMITTED) {
@@ -34,6 +35,15 @@ export default async function ApplicationPage({ params }: ApplicationPageProps) 
       if (!(error instanceof AxiosError && error.status === 404)) {
         redirect('/login');
       }
+    }
+  }
+  if (deadlinePassed) {
+    if (response) {
+      if (step < STEP_REVIEW) {
+        redirect(`/apply/${STEP_REVIEW}`);
+      }
+    } else {
+      redirect('/');
     }
   }
   const application = response ? applicationToResponses(response.data) : undefined;
@@ -57,6 +67,7 @@ export default async function ApplicationPage({ params }: ApplicationPageProps) 
           accessToken={accessToken}
           prev={`/apply/${appQuestions.length}`}
           next={`/apply/${STEP_SUBMITTED}`}
+          allowChanges={!deadlinePassed}
         />
       ) : step === STEP_SUBMITTED ? (
         <Card gap={2.5} className={styles.submitted}>

--- a/client/src/components/ApplicationReview/index.tsx
+++ b/client/src/components/ApplicationReview/index.tsx
@@ -146,7 +146,7 @@ const ApplicationReviewWrapped = ({
       .getItem<Responses | null>(SAVED_RESPONSES_KEY)
       .then(draftResponses => {
         if (draftResponses) {
-          setResponses({ ...submittedResponses, ...draftResponses });
+          setResponses(submittedResponses => ({ ...submittedResponses, ...draftResponses }));
         }
       })
       .finally(() => setResponsesLoaded(true));

--- a/client/src/components/ApplicationReview/index.tsx
+++ b/client/src/components/ApplicationReview/index.tsx
@@ -9,7 +9,6 @@ import { appQuestions } from '@/config';
 import { Fragment, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ResponseAPI } from '@/lib/api';
-import { Yes, YesOrNo } from '@/lib/types/enums';
 import showToast from '@/lib/showToast';
 import { Application } from '@/lib/types/application';
 import localforage from 'localforage';
@@ -23,6 +22,7 @@ interface ApplicationReviewProps {
   alreadySubmitted: boolean;
   prev: string;
   next: string;
+  allowChanges: boolean;
 }
 
 const ApplicationReview = ({
@@ -32,6 +32,7 @@ const ApplicationReview = ({
   alreadySubmitted,
   prev,
   next,
+  allowChanges,
 }: ApplicationReviewProps) => {
   const router = useRouter();
 
@@ -117,14 +118,16 @@ const ApplicationReview = ({
           ))}
       </dl>
 
-      <div className={styles.buttonRow}>
-        <Button href="/apply" variant="secondary">
-          Make Changes
-        </Button>
-        <Button submit disabled={!responsesLoaded}>
-          {alreadySubmitted ? 'Update' : 'Submit'}
-        </Button>
-      </div>
+      {allowChanges ? (
+        <div className={styles.buttonRow}>
+          <Button href="/apply" variant="secondary">
+            Make Changes
+          </Button>
+          <Button submit disabled={!responsesLoaded}>
+            {alreadySubmitted ? 'Update' : 'Submit'}
+          </Button>
+        </div>
+      ) : null}
     </Card>
   );
 };

--- a/client/src/components/ApplicationStep/index.tsx
+++ b/client/src/components/ApplicationStep/index.tsx
@@ -322,7 +322,7 @@ const ApplicationStepWrapped = ({
       .getItem<Responses | null>(SAVED_RESPONSES_KEY)
       .then(draftResponses => {
         if (draftResponses) {
-          setResponses({ ...submittedResponses, ...draftResponses });
+          setResponses(submittedResponses => ({ ...submittedResponses, ...draftResponses }));
         }
       })
       .finally(() => setResponsesLoaded(true));

--- a/client/src/components/Dashboard/index.tsx
+++ b/client/src/components/Dashboard/index.tsx
@@ -11,7 +11,7 @@ import { PrivateProfile } from '@/lib/types/apiResponses';
 
 type Status = 'NOT_SUBMITTED' | 'SUBMITTED' | 'WITHDRAWN' | 'ACCEPTED' | 'REJECTED' | 'CONFIRMED';
 
-/** Dates should be at 12 am UTC. */
+/** Dates are in local time (America/Los_Angeles) */
 export interface Deadlines {
   application: Date;
   decisions: Date;

--- a/client/src/components/DashboardStatus/index.tsx
+++ b/client/src/components/DashboardStatus/index.tsx
@@ -26,12 +26,16 @@ const statusText = (status: string) => {
   return formatted.charAt(0).toUpperCase() + formatted.slice(1);
 };
 
-const getStatusDescription = (status: string) => {
+const getStatusDescription = (timeline: Deadlines, status: Status) => {
   switch (status) {
     case 'SUBMITTED':
       return 'Congrats on applying to DiamondHacks!';
     default:
-      return 'Our records have indicated that you have not started on your application. Click below to go on your hacker journey!';
+      if (new Date() < timeline.application) {
+        return 'Our records have indicated that you have not started on your application. Click below to go on your hacker journey!';
+      } else {
+        return "Our records have indicated that you have not started on your application. Unfortunately, the deadline has passed, but we'd love to see you next year at DiamondHacks!";
+      }
   }
 };
 
@@ -41,7 +45,7 @@ const DashboardStatus = ({ status, timeline }: DashboardStatusProps) => {
     <>
       <div className={`${styles.badge} ${styles[status]}`}>Status: {statusText(status)}</div>
       <Typography variant="body/large" component="p">
-        {getStatusDescription(status)}
+        {getStatusDescription(timeline, status)}
       </Typography>
       <Typography variant="body/large" component="p">
         Please note that applications are due on {dateFormat.format(timeline.application)}.
@@ -52,7 +56,9 @@ const DashboardStatus = ({ status, timeline }: DashboardStatusProps) => {
       ) : status === 'ACCEPTED' ? (
         <Button>Confirm Acceptance</Button>
       ) : status === 'NOT_SUBMITTED' ? (
-        <Button href="/apply">Apply Now</Button>
+        new Date() < timeline.application ? (
+          <Button href="/apply">Apply Now</Button>
+        ) : null
       ) : status === 'SUBMITTED' ? (
         <Button href="/apply">
           {new Date() < timeline.application ? 'Edit Application' : 'View Application'}

--- a/client/src/components/DashboardStatus/index.tsx
+++ b/client/src/components/DashboardStatus/index.tsx
@@ -12,7 +12,7 @@ export type Status =
   | 'CONFIRMED';
 
 export const dateFormat = new Intl.DateTimeFormat('en-US', {
-  timeZone: 'UTC',
+  timeZone: 'America/Los_Angeles',
   dateStyle: 'full',
 });
 
@@ -54,7 +54,9 @@ const DashboardStatus = ({ status, timeline }: DashboardStatusProps) => {
       ) : status === 'NOT_SUBMITTED' ? (
         <Button href="/apply">Apply Now</Button>
       ) : status === 'SUBMITTED' ? (
-        <Button href="/apply">Edit Application</Button>
+        <Button href="/apply">
+          {new Date() < timeline.application ? 'Edit Application' : 'View Application'}
+        </Button>
       ) : null}
     </>
   );

--- a/client/src/components/TimelineItem/index.tsx
+++ b/client/src/components/TimelineItem/index.tsx
@@ -4,12 +4,12 @@ import { PropsWithChildren } from 'react';
 import CheckIcon from '@/../public/assets/icons/check.svg';
 
 export const dateFormat = new Intl.DateTimeFormat('en-US', {
-  timeZone: 'UTC',
+  timeZone: 'America/Los_Angeles',
   dateStyle: 'medium',
 });
 
 interface TimelineItemProps {
-  /** In UTC */
+  /** In local time (America/Los_Angeles) */
   date: Date;
   first?: boolean;
 }

--- a/client/src/components/admin/AdminDashboard/index.tsx
+++ b/client/src/components/admin/AdminDashboard/index.tsx
@@ -7,14 +7,7 @@ import Button from '@/components/Button';
 import TimelineItem from '@/components/TimelineItem';
 import ApplicationCount from '../ApplicationCount';
 import { PrivateProfile, ResponseModel } from '@/lib/types/apiResponses';
-
-/** Dates should be at 12 am UTC. */
-export interface Deadlines {
-  application: Date;
-  decisions: Date;
-  acceptance: Date;
-  hackathon: Date;
-}
+import { Deadlines } from '@/components/Dashboard';
 
 interface AdminDashboardProps {
   timeline: Deadlines;

--- a/client/src/config.tsx
+++ b/client/src/config.tsx
@@ -322,8 +322,8 @@ export const appQuestions: Step[] = [
 ];
 
 export const TIMELINE: Deadlines = {
-  application: new Date('2025-02-28'),
-  decisions: new Date('2025-03-07'),
-  acceptance: new Date('2025-03-21'),
-  hackathon: new Date('2025-04-05'),
+  application: new Date('2025-02-28T00:00-08:00'),
+  decisions: new Date('2025-03-07T00:00-08:00'),
+  acceptance: new Date('2025-03-21T00:00-07:00'),
+  hackathon: new Date('2025-04-05T00:00-07:00'),
 };


### PR DESCRIPTION
# Description

(Front-end only) Prevents creating/editing your application after the deadline

## Changes

- Application edit pages redirect to review (if you already submitted) or dashboard (if not)
- Buttons to edit the application are either hidden or changed to say "view"
- Changed the deadlines to be in Pacific Time (🙏 may Newsom end daylight savings)

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [x] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.