### PR TITLE
Allow admins to confirm users

### DIFF
--- a/client/src/app/liability/page.tsx
+++ b/client/src/app/liability/page.tsx
@@ -4,6 +4,7 @@ import { getCookie } from '@/lib/services/CookieService';
 import { CookieType, ApplicationStatus } from '@/lib/types/enums';
 import { redirect } from 'next/navigation';
 import styles from './page.module.scss';
+import { canUserSubmitWaivers } from '@/lib/utils';
 
 export default async function LiabilityPage() {
   const accessToken = await getCookie(CookieType.ACCESS_TOKEN);
@@ -20,7 +21,7 @@ export default async function LiabilityPage() {
   }
 
   // Only allow accepted participants to fill out liability form
-  if (fetchedUser.applicationStatus !== ApplicationStatus.ACCEPTED) {
+  if (!canUserSubmitWaivers(fetchedUser.applicationStatus)) {
     redirect('/profile');
   }
 

--- a/client/src/app/photoRelease/page.tsx
+++ b/client/src/app/photoRelease/page.tsx
@@ -4,6 +4,7 @@ import { getCookie } from '@/lib/services/CookieService';
 import { CookieType, ApplicationStatus } from '@/lib/types/enums';
 import { redirect } from 'next/navigation';
 import styles from './page.module.scss';
+import { canUserSubmitWaivers } from '@/lib/utils';
 
 export default async function PhotoReleasePage() {
   const accessToken = await getCookie(CookieType.ACCESS_TOKEN);
@@ -20,7 +21,7 @@ export default async function PhotoReleasePage() {
   }
 
   // Only allow accepted participants to fill out photo release form
-  if (fetchedUser.applicationStatus !== ApplicationStatus.ACCEPTED) {
+  if (!canUserSubmitWaivers(fetchedUser.applicationStatus)) {
     redirect('/profile');
   }
 

--- a/client/src/components/Profile/index.tsx
+++ b/client/src/components/Profile/index.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/Button';
 import styles from './style.module.scss';
 import { ApplicationStatus, FormType } from '@/lib/types/enums';
 import { PrivateProfile, ResponseModel } from '@/lib/types/apiResponses';
+import { canUserSubmitWaivers } from '@/lib/utils';
 
 interface ProfileClientProps {
   user: PrivateProfile;
@@ -27,7 +28,7 @@ const Profile = ({ user, responses }: ProfileClientProps) => {
   return (
     <div className={styles.profileContainer}>
       <ProfileCard user={user} />
-      {applicationStatus === ApplicationStatus.ACCEPTED && (
+      {canUserSubmitWaivers(applicationStatus) && (
         <div className={styles.formsContainer}>
           <Card gap={1.5} className={styles.liability}>
             <Heading>Liability Form Status</Heading>

--- a/client/src/components/admin/UsersDashboard/index.tsx
+++ b/client/src/components/admin/UsersDashboard/index.tsx
@@ -38,12 +38,7 @@ const UsersDashboard = ({ users }: UsersDashboardProps) => {
   const filteredUsers = users
     .filter(user => {
       if (filterStatus === 'All') return true;
-
-      if (user.applicationStatus === ApplicationStatus.NOT_SUBMITTED) {
-        return user.applicationStatus === filterStatus;
-      }
-
-      return user.applicationDecision === filterStatus;
+      return user.applicationStatus === filterStatus;
     })
     .filter(user =>
       `${user.firstName} ${user.lastName}`.toLowerCase().includes(searchQuery.toLowerCase())
@@ -61,7 +56,7 @@ const UsersDashboard = ({ users }: UsersDashboardProps) => {
     <div className={styles.container}>
       <div className={styles.filterContainer}>
         <div className={styles.filterButtons}>
-          {['All', 'NOT_SUBMITTED', ...Object.values(ApplicationDecision)].map(status => (
+          {['All', ...Object.values(ApplicationStatus)].map(status => (
             <Button
               key={status}
               onClick={() => {

--- a/client/src/lib/api/AdminAPI.ts
+++ b/client/src/lib/api/AdminAPI.ts
@@ -1,14 +1,14 @@
 import config from '@/lib/config';
-import type {
-  GetApplicationsResponse,
-  GetApplicationResponse,
-  GetUsersResponse,
-  GetUserApplicationResponse,
-  GetApplicationDecisionResponse,
-  UpdateApplicationDecisionResponse,
-  ResponseModel,
-  PrivateProfile,
-  FullProfile,
+import {
+  type GetApplicationsResponse,
+  type GetApplicationResponse,
+  type GetUsersResponse,
+  type GetUserApplicationResponse,
+  type GetApplicationDecisionResponse,
+  type UpdateApplicationDecisionResponse,
+  type ResponseModel,
+  type FullProfile,
+  ConfirmUserStatusResponse,
 } from '@/lib/types/apiResponses';
 import { ApplicationDecision } from '@/lib/types/enums';
 import axios from 'axios';
@@ -113,5 +113,21 @@ export const updateApplicationDecision = async (
       },
     }
   );
+  return response.data.user;
+};
+
+/**
+ * Updates user status to CONFIRMED in the portal.
+ * @param token
+ * @param id
+ * @returns User's updated profile.
+ */
+export const confirmUserStatus = async (token: string, id: string): Promise<FullProfile> => {
+  const requestUrl = `${config.api.baseUrl}${config.api.endpoints.admin.confirmUser}/${id}`;
+  const response = await axios.post<ConfirmUserStatusResponse>(requestUrl, null, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
   return response.data.user;
 };

--- a/client/src/lib/config.ts
+++ b/client/src/lib/config.ts
@@ -21,6 +21,7 @@ const config = {
         application: '/admin/application',
         users: '/admin/users',
         userApplication: '/admin/user',
+        confirmUser: '/admin/user/confirm',
       },
     },
   },

--- a/client/src/lib/types/apiResponses.ts
+++ b/client/src/lib/types/apiResponses.ts
@@ -133,3 +133,7 @@ export interface GetApplicationDecisionResponse extends ApiResponse {
 export interface UpdateApplicationDecisionResponse extends ApiResponse {
   user: FullProfile;
 }
+
+export interface ConfirmUserStatusResponse extends ApiResponse {
+  user: FullProfile;
+}

--- a/client/src/lib/types/enums.ts
+++ b/client/src/lib/types/enums.ts
@@ -6,12 +6,12 @@ export enum UserAccessType {
 }
 
 export enum ApplicationStatus {
+  CONFIRMED = 'CONFIRMED',
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED',
   NOT_SUBMITTED = 'NOT_SUBMITTED',
   SUBMITTED = 'SUBMITTED',
   WITHDRAWN = 'WITHDRAWN',
-  ACCEPTED = 'ACCEPTED',
-  REJECTED = 'REJECTED',
-  CONFIRMED = 'CONFIRMED',
 }
 
 export enum ApplicationDecision {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import type { ApiResponse, CustomErrorBody, ValidatorError } from '@/lib/types/apiResponses';
 import showToast from '@/lib/showToast';
 import { AxiosError } from 'axios';
+import { ApplicationStatus } from './types/enums';
 
 /**
  * Parse nested error object for messages
@@ -49,4 +50,11 @@ export function getErrorMessage(error: unknown): string {
  */
 export function reportError(title: string, error: unknown) {
   showToast(title, getErrorMessage(error));
+}
+
+export function canUserSubmitWaivers(applicationStatus: ApplicationStatus): boolean {
+  return (
+    applicationStatus === ApplicationStatus.ACCEPTED ||
+    applicationStatus === ApplicationStatus.CONFIRMED
+  );
 }

--- a/server/api/controllers/AdminController.ts
+++ b/server/api/controllers/AdminController.ts
@@ -22,6 +22,7 @@ import { UserService } from '../../services/UserService';
 import { ResponseService } from '../../services/ResponseService';
 import { IdParam } from '../validators/GenericRequests';
 import PermissionsService from '../../services/PermissionsService';
+import { ApplicationStatus } from '../../types/Enums';
 
 @JsonController('/admin')
 @Service()
@@ -90,6 +91,24 @@ export class AdminController {
     return { error: null, user: user.getHiddenProfile() };
   }
 
+
+
+  @UseBefore(UserAuthentication)
+  @Post('/user/confirm/:id')
+  async confirmUserStatus(
+    @AuthenticatedUser() currentUser: UserModel,
+    @Params() params: IdParam,
+  ) {
+    if (!PermissionsService.canEditApplicationDecisions(currentUser))
+      throw new ForbiddenError();
+
+    const user = await this.userService.updateUserStatus(
+      params.id,
+      ApplicationStatus.CONFIRMED
+    );
+    return { error: null, user };
+  }
+
   @UseBefore(UserAuthentication)
   @Get('/users')
   async getUsers(@AuthenticatedUser() currentUser: UserModel) {
@@ -127,6 +146,5 @@ export class AdminController {
     const responses = await this.responseService.getUserWaivers(user);
     return { error: null, responses: responses };
   }
-
 
 }

--- a/server/api/controllers/AdminController.ts
+++ b/server/api/controllers/AdminController.ts
@@ -104,7 +104,7 @@ export class AdminController {
 
     const user = await this.userService.updateUserStatus(
       params.id,
-      ApplicationStatus.CONFIRMED
+      ApplicationStatus.CONFIRMED,
     );
     return { error: null, user };
   }

--- a/server/services/ResponseService.ts
+++ b/server/services/ResponseService.ts
@@ -219,7 +219,10 @@ export class ResponseService {
     formData: Waiver,
     formType: FormType,
   ): Promise<ResponseModel> {
-    if (user.applicationStatus !== ApplicationStatus.ACCEPTED) {
+    if (
+      user.applicationStatus !== ApplicationStatus.ACCEPTED &&
+      user.applicationStatus !== ApplicationStatus.CONFIRMED
+    ) {
       throw new BadRequestError(
         'User must have an accepted application to submit this form.');
     }

--- a/server/services/UserService.ts
+++ b/server/services/UserService.ts
@@ -17,7 +17,7 @@ import {
 import { UpdateUser } from '../api/validators/UserControllerRequests';
 import { auth, adminAuth } from '../FirebaseAuth';
 import { UserAndToken } from '../types/ApiResponses';
-import { ApplicationDecision } from '../types/Enums';
+import { ApplicationDecision, ApplicationStatus } from '../types/Enums';
 
 @Service()
 export class UserService {
@@ -120,6 +120,20 @@ export class UserService {
     this.transactionsManager.readWrite(async (entityManager) =>
       Repositories.user(entityManager).remove(user),
     );
+  }
+
+  public async updateUserStatus(
+    userId: string,
+    applicationStatus: ApplicationStatus,
+  ): Promise<UserModel> {
+    return this.transactionsManager.readWrite(async (entityManager) => {
+      const userRepository = Repositories.user(entityManager);
+      const user = await userRepository.findById(userId);
+      if (!user) throw new NotFoundError('User not found');
+      user.applicationStatus = applicationStatus;
+      const updatedUser = userRepository.save(user);
+      return updatedUser;
+    });
   }
 
   public async updateApplicationDecision(


### PR DESCRIPTION
- We were originally going to have users RSVP through the portal and have that mark them as confirmed, but we ended up using a google form. Now adding a way for admins to mark users as confirmed going off of the google form

- Added a backend route to do this
- Add confirm button in application view
- Update dashboard to filter on application status since we manually updated app status to match app decision