### PR TITLE
hotfix: use user ID for pass object ID

### DIFF
--- a/client/src/components/Dashboard/wallet.ts
+++ b/client/src/components/Dashboard/wallet.ts
@@ -36,7 +36,7 @@ export async function addToGoogleWallet(baseUrl: string): Promise<string> {
       genericClass = await client.patchClass(classData);
     }
 
-    const objectSuffix = 'diamondhacks2025';
+    const objectSuffix = user.id;
     const objectId = `${ISSUER_ID}.${objectSuffix}`;
     const objectData: GenericObject = {
       id: objectId,


### PR DESCRIPTION
oops

# Info

Addresses **#99**.

# Description

Right now, the Google Wallet passes are global, so when someone adds a pass to their Google Wallet, it changes the name and QR code for everyone else that has that pass. This is because I forgot to make the object ID based on the user's ID

# Type of Change

- [x] Patch (non-breaking change/bugfix)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally.
- [ ] on the testing API/testing database.
- [ ] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [x] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.