### PR TITLE
Nandita/pagination and consistent ordering

### DIFF
--- a/server/api/controllers/AdminController.ts
+++ b/server/api/controllers/AdminController.ts
@@ -26,6 +26,7 @@ import {
   UpdateUserAccessResponse,
 } from '../../types/ApiResponses';
 import {
+  PaginationQueryParams,
   UpdateApplicationDecisionRequest,
   UpdateUserAccessRequest,
 } from '../validators/AdminControllerRequests';
@@ -91,11 +92,12 @@ export class AdminController {
   @Get('/applications')
   async getApplications(
     @AuthenticatedUser() user: UserModel,
+    @QueryParams() filters: PaginationQueryParams,
   ): Promise<GetFormsResponse> {
     if (!PermissionsService.canViewAllApplications(user))
       throw new ForbiddenError();
-
-    const responses = await this.responseService.getAllApplications();
+    const { offset, limit } = filters;
+    const responses = await this.responseService.getAllApplications(offset, limit);
     return { error: null, responses: responses };
   }
 

--- a/server/api/controllers/AdminController.ts
+++ b/server/api/controllers/AdminController.ts
@@ -97,7 +97,7 @@ export class AdminController {
     if (!PermissionsService.canViewAllApplications(user))
       throw new ForbiddenError();
     const { offset, limit } = filters;
-    const responses = await this.responseService.getAllApplications(offset, limit);
+    const responses = await this.responseService.getAllApplicationsSorted(offset, limit);
     return { error: null, responses: responses };
   }
 

--- a/server/api/validators/AdminControllerRequests.ts
+++ b/server/api/validators/AdminControllerRequests.ts
@@ -1,6 +1,7 @@
-import { IsBoolean, IsDefined, IsEmail, IsIn, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsDefined, IsEmail, IsIn, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
 import { UpdateApplicationDecisionRequest as IUpdateApplicationDecisionRequest } from '../../types/ApiRequests';
 import { UpdateUserAccessRequest as  IUpdateUserAccessRequest } from '../../types/ApiRequests';
+import { PaginationQueryParams as IPaginationQueryParams } from '../../types/ApiRequests';
 import { ApplicationDecision, UserAccessType } from '../../types/Enums';
 import { IsEduEmail, IsValidApplicationDecision } from '../decorators/Validators';
 
@@ -10,6 +11,16 @@ const AllowedRolesForUpdate = [
   UserAccessType.MANAGER,
   UserAccessType.ADMIN,
 ];
+
+export class PaginationQueryParams implements IPaginationQueryParams {
+  @IsOptional()
+  @Min(0)
+  offset?: number;
+
+  @IsOptional()
+  @Min(0)
+  limit?: number;
+}
 
 export class UpdateApplicationDecisionRequest implements IUpdateApplicationDecisionRequest {
   @IsDefined()

--- a/server/services/ResponseService.ts
+++ b/server/services/ResponseService.ts
@@ -51,16 +51,24 @@ export class ResponseService {
     return responses;
   }
 
-  private async getAllResponsesSorted(): Promise<ResponseModel[]> {
+  private async getAllApplicationsSorted(offset?: number, limit?: number): Promise<ResponseModel[]> {
     const sortedResponses = await this.transactionsManager.readOnly(
       async (entityManager) => {
 
         const repository = Repositories.response(entityManager);
-        return repository
-        .createQueryBuilder('Response')
-        .orderBy('Response.createdAt', 'DESC')
-        .getMany();
+        return repository.find({
+          where: {
+            formType: FormType.APPLICATION,
+          },
+          order: {
+            createdAt: 'DESC',
+          },
+          skip: offset,
+          take: limit,
+
+        });
       });
+
     return sortedResponses;
   }
 
@@ -108,11 +116,12 @@ export class ResponseService {
     }
   }
 
-  public async getAllApplications(): Promise<ResponseModel[]> {
-    const responses = await this.getAllResponsesSorted();
-    const applications = responses.filter(
-      (response) => response.formType === FormType.APPLICATION,
-    );
+  public async getAllApplications(offset?: number, limit?: number): Promise<ResponseModel[]> {
+
+    const applications = await this.getAllApplicationsSorted(offset, limit);
+    // const applications = responses.filter(
+    //   (response) => response.formType === FormType.APPLICATION,
+    // );
 
     return applications;
   }

--- a/server/services/ResponseService.ts
+++ b/server/services/ResponseService.ts
@@ -51,6 +51,19 @@ export class ResponseService {
     return responses;
   }
 
+  private async getAllResponsesSorted(): Promise<ResponseModel[]> {
+    const sortedResponses = await this.transactionsManager.readOnly(
+      async (entityManager) => {
+
+        const repository = Repositories.response(entityManager);
+        return repository
+        .createQueryBuilder("Response")
+        .orderBy("Response.createdAt", "DESC")
+        .getMany();
+      });
+    return sortedResponses;
+  }
+
   private async getAllResponsesWithReviewerRelation(): Promise<ResponseModel[]> {
     const responses = await this.transactionsManager.readOnly(
       async (entityManager) =>
@@ -96,10 +109,11 @@ export class ResponseService {
   }
 
   public async getAllApplications(): Promise<ResponseModel[]> {
-    const responses = await this.getAllResponses();
+    const responses = await this.getAllResponsesSorted();
     const applications = responses.filter(
       (response) => response.formType === FormType.APPLICATION,
     );
+
     return applications;
   }
 
@@ -110,6 +124,7 @@ export class ResponseService {
     );
     return applications;
   }
+
 
   public async submitUserApplication(
     user: UserModel,

--- a/server/services/ResponseService.ts
+++ b/server/services/ResponseService.ts
@@ -57,8 +57,8 @@ export class ResponseService {
 
         const repository = Repositories.response(entityManager);
         return repository
-        .createQueryBuilder("Response")
-        .orderBy("Response.createdAt", "DESC")
+        .createQueryBuilder('Response')
+        .orderBy('Response.createdAt', 'DESC')
         .getMany();
       });
     return sortedResponses;

--- a/server/services/ResponseService.ts
+++ b/server/services/ResponseService.ts
@@ -43,7 +43,7 @@ export class ResponseService {
     return response;
   }
 
-  private async getAllResponses(): Promise<ResponseModel[]> {
+  public async getAllResponses(): Promise<ResponseModel[]> {
     const responses = await this.transactionsManager.readOnly(
       async (entityManager) =>
         Repositories.response(entityManager).findAll(),
@@ -51,7 +51,7 @@ export class ResponseService {
     return responses;
   }
 
-  private async getAllApplicationsSorted(offset?: number, limit?: number): Promise<ResponseModel[]> {
+  public async getAllApplicationsSorted(offset?: number, limit?: number): Promise<ResponseModel[]> {
     const sortedResponses = await this.transactionsManager.readOnly(
       async (entityManager) => {
 
@@ -61,7 +61,7 @@ export class ResponseService {
             formType: FormType.APPLICATION,
           },
           order: {
-            createdAt: 'DESC',
+            createdAt: 'ASC',
           },
           skip: offset,
           take: limit,
@@ -116,15 +116,6 @@ export class ResponseService {
     }
   }
 
-  public async getAllApplications(offset?: number, limit?: number): Promise<ResponseModel[]> {
-
-    const applications = await this.getAllApplicationsSorted(offset, limit);
-    // const applications = responses.filter(
-    //   (response) => response.formType === FormType.APPLICATION,
-    // );
-
-    return applications;
-  }
 
   public async getAllApplicationsWithReviewerRelation(): Promise<ResponseModel[]> {
     const responses = await this.getAllResponsesWithReviewerRelation();

--- a/server/types/ApiRequests.ts
+++ b/server/types/ApiRequests.ts
@@ -121,3 +121,7 @@ export interface AddListOfInterestedPhoneRequest {
   phones: string[];
 }
 
+export interface PaginationQueryParams {
+  offset?: number;
+  limit?: number;
+}


### PR DESCRIPTION
# Info

Closes **[#229]**. 

# Description

Needed consistent ordering of applications when sending to frontend. Also, pagination of the applications was needed.

## Changes

- Used order by in a find query to order by createdAt date in descending order.
- Used skip and take in a find query to add offset and limits when retrieving the applications from the DB.
- Added the query parameters offset and limit as optional in the GET /admin/applications endpoint.

# Type of Change

- [ ] Patch (non-breaking change/bugfix)
- [X] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (A change to a README/description)
- [ ] Continuous Integration/DevOps Change (Related to deployment steps, continuous integration
      workflows, linting, etc.)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

If you've selected Patch, Minor, or Major as your change type, **make sure to bump the version before merging in `package.json`!**
# Testing

I have tested that my changes fully resolve the linked issue ...

- [X] locally.
- [ ] on the testing API/testing database.
- [X] with appropriate Postman routes. Screenshots are included below.

# Checklist

- [X] I have performed a self-review of my own code.
- [X] I have followed the style guidelines of this project.
- [ ] I have appropriately edited the API version in the `package.json` file.
- [X] My changes produce no new warnings.

# Screenshots

Please include a screenshot of your Postman testing passing successfully.